### PR TITLE
fix sort order for masternode active time

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -197,12 +197,14 @@ void MasternodeList::updateMyMasternodeInfo(QString strAlias, QString strAddr, c
 
     masternode_info_t infoMn;
     bool fFound = mnodeman.GetMasternodeInfo(outpoint, infoMn);
+    int64_t active_seconds;
 
     QTableWidgetItem *aliasItem = new QTableWidgetItem(strAlias);
     QTableWidgetItem *addrItem = new QTableWidgetItem(fFound ? QString::fromStdString(infoMn.addr.ToString()) : strAddr);
     QTableWidgetItem *protocolItem = new QTableWidgetItem(QString::number(fFound ? infoMn.nProtocolVersion : -1));
     QTableWidgetItem *statusItem = new QTableWidgetItem(QString::fromStdString(fFound ? CMasternode::StateToString(infoMn.nActiveState) : "MISSING"));
-    QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::fromStdString(DurationToDHMS(fFound ? (infoMn.nTimeLastPing - infoMn.sigTime) : 0)));
+    active_seconds = fFound ? (infoMn.nTimeLastPing - infoMn.sigTime) : 0;
+    QTableWidgetItem *activeSecondsItem = new QTableNumItem(active_seconds,QString::fromStdString(DurationToDHMS(active_seconds)));
     QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M",
                                                                                                    fFound ? infoMn.nTimeLastPing + GetOffsetFromUtc() : 0)));
     QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(fFound ? CBitcoinAddress(infoMn.pubKeyCollateralAddress.GetID()).ToString() : ""));
@@ -275,6 +277,7 @@ void MasternodeList::updateNodeList()
     ui->tableWidgetMasternodes->setRowCount(0);
     std::map<COutPoint, CMasternode> mapMasternodes = mnodeman.GetFullMasternodeMap();
     int offsetFromUtc = GetOffsetFromUtc();
+    int64_t active_seconds;
 
     for(auto& mnpair : mapMasternodes)
     {
@@ -284,7 +287,8 @@ void MasternodeList::updateNodeList()
         QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
         QTableWidgetItem *protocolItem = new QTableWidgetItem(QString::number(mn.nProtocolVersion));
         QTableWidgetItem *statusItem = new QTableWidgetItem(QString::fromStdString(mn.GetStatus()));
-        QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::fromStdString(DurationToDHMS(mn.lastPing.sigTime - mn.sigTime)));
+        active_seconds = mn.lastPing.sigTime - mn.sigTime;
+        QTableWidgetItem *activeSecondsItem = new QTableNumItem(active_seconds,QString::fromStdString(DurationToDHMS(active_seconds)));
         QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M", mn.lastPing.sigTime + offsetFromUtc)));
         QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(CBitcoinAddress(mn.pubKeyCollateralAddress.GetID()).ToString()));
 

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -9,6 +9,7 @@
 #include <QMenu>
 #include <QTimer>
 #include <QWidget>
+#include <QtWidgets/QTableWidget>
 
 #define MY_MASTERNODELIST_UPDATE_SECONDS                 60
 #define MASTERNODELIST_UPDATE_SECONDS                    15
@@ -24,6 +25,31 @@ class WalletModel;
 QT_BEGIN_NAMESPACE
 class QModelIndex;
 QT_END_NAMESPACE
+
+class QTableNumItem : public QTableWidgetItem
+{
+
+public:
+    QTableNumItem(int64_t n, QString const & text)
+        : QTableWidgetItem(text)
+        , f_value(n)
+    {
+    }
+
+    bool operator < (QTableWidgetItem const & rhs) const
+    {
+        QTableNumItem const * r(dynamic_cast<QTableNumItem const *>(&rhs));
+        if(r == nullptr)
+        {
+            return false;
+        }
+        return f_value < r->f_value;
+    }
+
+private:
+    int64_t      f_value = 0;
+};
+
 
 /** Masternode Manager page widget */
 class MasternodeList : public QWidget


### PR DESCRIPTION
This patch implements custom sort for active time in masternode list so that the times are in correct order

Before:
![before](https://user-images.githubusercontent.com/43784463/46414749-b6387d80-c71b-11e8-8543-33682da1a7f7.png)
After:
![after](https://user-images.githubusercontent.com/43784463/46414751-b6387d80-c71b-11e8-9cb8-5ffad62ade37.png)
